### PR TITLE
Bug: fix maximum recursion limit

### DIFF
--- a/src/experts/deepresearch_bot/state.py
+++ b/src/experts/deepresearch_bot/state.py
@@ -18,6 +18,7 @@ class OverallState(TypedDict):
     initial_search_query_count: int
     max_research_loops: int
     research_loop_count: int
+    current_queries: list[str]
 
 
 class ReflectionState(TypedDict):


### PR DESCRIPTION
Root cause:

> The original implementation used a "fan-out" pattern where each search query triggered a parallel branch in the graph. Each branch then fed into the `reflection` node. Since LangGraph counts each node execution towards the recursion limit, processing multiple queries in parallel caused the research_loop_count (and the graph step count) to increase rapidly, hitting the default limit.

The Fix

> I refactored the workflow to use a batch processing approach:
> 
> 1. **State Update**: Added current_queries to `OverallState` to hold the batch of queries to be processed.
> 
> 2. **Sequential Execution**:
> 
> - `generate_query` now populates current_queries.
> 
> - `web_research` now iterates through all current_queries in a single node execution, aggregating the results.
> 
> - `reflection` runs once for the entire batch of results.
> 
> 3. **Loop Counting**: The `research_loop_count` now increments only once per batch of queries, correctly reflecting the logical research loops.

Logic Refinement

> To prevent infinite loops where the bot repeatedly asks the same questions or gets stuck when no new queries are generated, I implemented:
> 
> - Query Deduplication: In the `reflection` node, new queries are checked against all past queries. Duplicates are filtered out.
> 
> - Empty Check: In the `evaluate_research` edge, if the list of new queries is empty (after deduplication), the workflow terminates early and finalizes the answer.
